### PR TITLE
Adjust z-index and image styles for About and Hero blur

### DIFF
--- a/src/components/AboutSection.vue
+++ b/src/components/AboutSection.vue
@@ -1,5 +1,5 @@
 <template>
-  <section class="px-4 md:px-24 lg:px-32 py-30 text-white">
+  <section class="relative z-2 px-4 md:px-24 lg:px-32 py-30 text-white">
     <h1 class="text-4xl sm:text-5xl font-bold mb-12 text-center">About YAMP</h1>
     <div class="max-w-3xl mx-auto">
       <p class="text-white/80 leading-relaxed mb-6 text-lg">

--- a/src/components/HeroBottomBlur.vue
+++ b/src/components/HeroBottomBlur.vue
@@ -23,6 +23,12 @@ import heroBlurImage from "@/assets/hero-bottom-blur.webp";
   overflow: hidden;
 }
 
+.hero-bottom-blur img {
+  -webkit-user-drag: none;
+  position: relative;
+  z-index: 0;
+}
+
 /* Fade-in animation */
 .blur-fade-enter-active {
   transition: all 1.2s ease-out;


### PR DESCRIPTION
Added relative positioning and z-index to AboutSection for stacking context.
Updated HeroBottomBlur image styles to prevent dragging and set z-index, improving layout and user experience.

Before (When users were trying to copy the text from bottom):
![image](https://github.com/user-attachments/assets/e2f59a81-1a2d-4871-96ac-30d529a00c78)

After:
![image](https://github.com/user-attachments/assets/c9872252-20ae-4532-a2eb-8658c45e990e)

